### PR TITLE
adding logic for virtual field

### DIFF
--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -163,8 +163,9 @@ const getQueryDetailFields = (schema: any, modelName: any) => {
   const detailFields = schema.getDetailFields({ modelName, customProps: {} })
   const fields = R.filter(
     (field: any) =>
-      R.includes(R.prop('fieldName', field), detailFields) ||
-      R.prop('queryDetail', field),
+      (R.includes(R.prop('fieldName', field), detailFields) ||
+        R.prop('queryDetail', field)) &&
+      !R.prop('virtualField', field),
     schema.getFields(modelName)
   )
   return R.mapObjIndexed(


### PR DESCRIPTION
Added the logic needed for the virtualField attribute that negates the need to build a back-end resolver for custom fields.

Tested and working in the Autoinvent example:
![image](https://user-images.githubusercontent.com/33336510/95385967-893b7a00-08a3-11eb-9c3b-ec27d9c31322.png)



