### PR TITLE
showDeleteModal support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autoinvent/magql-query",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Query builder for communicating with magql backend.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -341,7 +341,8 @@ const buildSearchFieldsObject = (schema: SchemaBuilder, model: any) => {
 const buildDeleteCascadesArray = (schema: SchemaBuilder) => {
   const cascadesArray: object[] = []
   R.forEachObjIndexed(model => {
-    cascadesArray.push(buildCascadesObject(schema, model))
+    if (!R.propEq('showDeleteModal', false, model))
+      cascadesArray.push(buildCascadesObject(schema, model))
   }, schema.schemaJSON)
   return cascadesArray
 }


### PR DESCRIPTION
Prevents models that have the `showDeleteModal: false` metadata from being included in the checkDelete query