### PR TITLE
Bugfix when passing function in 'displayField'

### DIFF
--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -224,10 +224,12 @@ const getRelFieldObject = ({
     'name',
     'displayField',
     schema.getModel(targetModel)
-  ) as string
-  if (targetModelDisplayField) {
+  )
+  if (typeof targetModelDisplayField === 'function') {
+    relFieldObject[targetModelDisplayField()] = true
+  } else if (typeof targetModelDisplayField === 'string') {
     relFieldObject[targetModelDisplayField] = true
-  } // todo: targetModelDisplayField can be function and not string???
+  }
   return relFieldObject
 }
 


### PR DESCRIPTION
fixes #10 
Type check at getRelFieldObject
Note: Used 'typeof' instead of R.type() since R.type() has type errors